### PR TITLE
Adds fix for ShaaveChild.sol/short() accounting

### DIFF
--- a/src/contracts/ShaaveChild.sol
+++ b/src/contracts/ShaaveChild.sol
@@ -97,6 +97,7 @@ contract ShaaveChild is Ownable {
         // 4. Update user's accounting
         if (userPositions[_shortTokenAddress][_baseTokenAddress].shortTokenAddress == address(0)) {
             userPositions[_shortTokenAddress][_baseTokenAddress].shortTokenAddress = _shortTokenAddress;
+            userPositions[_shortTokenAddress][_baseTokenAddress].baseTokenAddress  = _baseTokenAddress;
         }
 
         if (!openShortPositions.includes(_shortTokenAddress)) {


### PR DESCRIPTION
Adds an update to the accounting data's `_baseTokenAddress`. The ShaaveChild contract needs this update for [getAccountingData()](https://github.com/shaave/v1-core/blob/66cb9a39bcc02f4af5b4803c1f4f1e17c2639fa1/src/contracts/ShaaveChild.sol#L361) to work properly.  